### PR TITLE
Extract constructor to parent class

### DIFF
--- a/fastapi_another_jwt_auth/exceptions.py
+++ b/fastapi_another_jwt_auth/exceptions.py
@@ -2,7 +2,7 @@ class AuthJWTException(Exception):
     """
     Base except which all fastapi_another_jwt_auth errors extend
     """
-    def __init__(self,status_code: int, message: str):
+    def __init__(self, status_code: int, message: str):
         self.status_code = status_code
         self.message = message
 

--- a/fastapi_another_jwt_auth/exceptions.py
+++ b/fastapi_another_jwt_auth/exceptions.py
@@ -2,71 +2,57 @@ class AuthJWTException(Exception):
     """
     Base except which all fastapi_another_jwt_auth errors extend
     """
-    pass
+    def __init__(self,status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
 
 class InvalidHeaderError(AuthJWTException):
     """
     An error getting jwt in header or jwt header information from a request
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class JWTDecodeError(AuthJWTException):
     """
     An error decoding a JWT
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class CSRFError(AuthJWTException):
     """
     An error with CSRF protection
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class MissingTokenError(AuthJWTException):
     """
     Error raised when token not found
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class RevokedTokenError(AuthJWTException):
     """
     Error raised when a revoked token attempt to access a protected endpoint
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class AccessTokenRequired(AuthJWTException):
     """
     Error raised when a valid, non-access JWT attempt to access an endpoint
     protected by jwt_required, jwt_optional, fresh_jwt_required
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class RefreshTokenRequired(AuthJWTException):
     """
     Error raised when a valid, non-refresh JWT attempt to access an endpoint
     protected by jwt_refresh_token_required
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass
 
 class FreshTokenRequired(AuthJWTException):
     """
     Error raised when a valid, non-fresh JWT attempt to access an endpoint
     protected by fresh_jwt_required
     """
-    def __init__(self,status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
+    pass


### PR DESCRIPTION
When handling errors as demonstrated [here](https://glitchcorp.github.io/fastapi-another-jwt-auth/usage/basic/), the `exc` object has no known members of `status_code` or `message`.

This change provides those members to `AuthJWTException` and all of its subclasses and prevents duplication.