### PR TITLE
optional type and strictBytes typing on secret key

### DIFF
--- a/fastapi_another_jwt_auth/auth_jwt.py
+++ b/fastapi_another_jwt_auth/auth_jwt.py
@@ -616,7 +616,7 @@ class AuthJWT(AuthConfig):
         issuer = self._decode_issuer if type_token == 'access' else None
         self._verifying_token(token,issuer)
 
-        if self.get_raw_jwt(token)['type'] != type_token:
+        if 'type' in  self.get_raw_jwt(token) and self.get_raw_jwt(token)['type'] != type_token:
             msg = "Only {} tokens are allowed".format(type_token)
             if type_token == 'access':
                 raise AccessTokenRequired(status_code=422,message=msg)
@@ -634,7 +634,7 @@ class AuthJWT(AuthConfig):
         :param issuer: expected issuer in the JWT
         """
         raw_token = self._verified_token(encoded_token,issuer)
-        if raw_token['type'] in self._denylist_token_checks:
+        if raw_token.get('type') in self._denylist_token_checks:
             self._check_token_is_revoked(raw_token)
 
     def _verified_token(self,encoded_token: str, issuer: Optional[str] = None) -> Dict[str,Union[str,int,bool]]:

--- a/fastapi_another_jwt_auth/config.py
+++ b/fastapi_another_jwt_auth/config.py
@@ -4,6 +4,7 @@ from pydantic import (
     field_validator, ConfigDict, BaseModel,
     validator,
     StrictBool,
+    StrictBytes,
     StrictInt,
     StrictStr
 )
@@ -12,7 +13,7 @@ MyType = Union[Sequence[Any], Set[Any]]
 
 class LoadConfig(BaseModel):
     authjwt_token_location: Optional[Union[Sequence[StrictStr], Set[StrictStr]]] = {'headers'}
-    authjwt_secret_key: Optional[StrictStr] = None
+    authjwt_secret_key: Optional[Union[StrictStr,StrictBytes]] = None
     authjwt_public_key: Optional[StrictStr] = None
     authjwt_private_key: Optional[StrictStr] = None
     authjwt_algorithm: Optional[StrictStr] = "HS256"


### PR DESCRIPTION
hi there, couple of small tweaks :)

make the type optional
support StrictBytes on secret key

> "type": "access"

This seems to be a non standard jwt claim specific to this package, we are using existing jwt so need to make this optional. Likewise StrictBytes for HS256 as it should allow byte not just str.
